### PR TITLE
One program block per socat command in supervisor-socat.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,7 @@ RUN apt-get update -qq -y && \
     apt-get install -qq -y socat supervisor && \
     apt-get clean
 
-ADD /start-socat.sh /start-socat.sh
 ADD /run.sh /run.sh
-
-ADD /supervisord-socat.conf /etc/supervisor/conf.d/supervisord-socat.conf
 RUN chmod 755 /*.sh
 
 CMD ["/run.sh"]

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-rm -fr /etc/supervisor/conf.d/socat*
+rm -fr /etc/supervisor/conf.d/supervisor-socat.conf
 env | grep _TCP= | while read line; do
   name=$(echo $line | sed -e 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat_\1_\2_\3/')
   cmd=$(echo $line | sed -e 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -ls TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3/')
       
-  cat <<EOF > /etc/supervisor/conf.d/supervisor-$name.conf
+  cat <<EOF >> /etc/supervisor/conf.d/supervisor-socat.conf
 [program:$name]
 command=$cmd
 numprocs=1

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,17 @@
 #!/bin/bash
+rm -fr /etc/supervisor/conf.d/socat*
+env | grep _TCP= | while read line; do
+  name=$(echo $line | sed -e 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat_\1_\2_\3/')
+  cmd=$(echo $line | sed -e 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -ls TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3/')
+      
+  cat <<EOF > /etc/supervisor/conf.d/supervisor-$name.conf
+[program:$name]
+command=$cmd
+numprocs=1
+autostart=true
+autorestart=true
+EOF
+
+done
+
 exec supervisord -n

--- a/start-socat.sh
+++ b/start-socat.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-env | grep _TCP= | sed 's/.*_PORT_\([0-9]*\)_TCP=tcp:\/\/\(.*\):\(.*\)/socat -ls TCP4-LISTEN:\1,fork,reuseaddr TCP4:\2:\3 \&/'  | sh

--- a/supervisord-socat.conf
+++ b/supervisord-socat.conf
@@ -1,5 +1,0 @@
-[program:socat]
-command=/start-socat.sh
-numprocs=1
-autostart=true
-autorestart=true


### PR DESCRIPTION
I think this may be an alternate solution to issue #2 (possibly issue #1, but I'm not so sure about that).

This approach allows supervisord to watch and manage each socat command separately instead of letting them vanish under the sh process.

One thing this means is that if a sub-image replaces the /run.sh CMD, they will have to be responsible for doing the supervisor-socat.conf generation now done in that file.
